### PR TITLE
replace IMSLP_SCRAPE_CATCHART_NEXT_CLASS variable

### DIFF
--- a/imslp/interfaces/scraping.py
+++ b/imslp/interfaces/scraping.py
@@ -31,7 +31,7 @@ IMSLP_SCRAPE_CATCHART_URL = IMSLP_BASE_URL.format("/index.php?title={}&customcat
 
 # class name and content string used to locate chart of works
 IMSLP_SCRAPE_CATCHART_TABLE_CLASS = "wikitable"
-IMSLP_SCRAPE_CATCHART_NEXT_CLASS = "next 200"
+IMSLP_SCRAPE_CATCHART_NEXT_CLASS = "categorypaginglink"
 IMSLP_SCRAPE_CATCHART_NEXT_TEXT = "next 200"
 
 
@@ -108,7 +108,6 @@ def fetch_category_table(category_name: str, subcategory: typing.Optional[str] =
     rows_as_dicts = list(map(lambda parsed_row: dict(zip(header, parsed_row)), rows_parsed))
 
     return rows_as_dicts
-
 
 def fetch_images_metadata(page: mwclient.page.Page) -> list:
     """


### PR DESCRIPTION
I noticed that calling fetch_category_table from scraping.py was only returning the first page of the table, not going further. It seems like I've fixed this by updating `IMSLP_SCRAPE_CATCHART_NEXT_CLASS` to `"categorypaginglink"` from `"next 200"`(see https://imslp.org/index.php?title=Category:Beethoven%2C%20Ludwig%20van&customcat=ccperson1 for example,inspecting the Next 200 link at the bottom of the page).

